### PR TITLE
Allow logging in to previously authenticated servers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,11 +65,9 @@ dependencies {
     implementation(libs.koin.android)
 
     // Compose
-    implementation(libs.accompanist.navigation)
-    implementation(platform(libs.compose.bom))
+    implementation(libs.androidx.navigation)
     implementation(libs.bundles.compose)
     debugImplementation(libs.bundles.compose.tooling)
-    androidTestImplementation(platform(libs.compose.bom))
     androidTestImplementation(libs.compose.ui.test.junit4)
 
     testImplementation(libs.junit)

--- a/app/src/main/java/com/boswelja/truemanager/MainActivity.kt
+++ b/app/src/main/java/com/boswelja/truemanager/MainActivity.kt
@@ -10,11 +10,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
 import com.boswelja.truemanager.auth.ui.authNavigation
 import com.boswelja.truemanager.reporting.reportingGraph
 import com.boswelja.truemanager.ui.theme.TrueManagerTheme
-import com.google.accompanist.navigation.animation.AnimatedNavHost
-import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -30,9 +30,9 @@ class MainActivity : ComponentActivity() {
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalAnimationApi::class)
 @Composable
 fun MainScreen() {
-    val navController = rememberAnimatedNavController()
+    val navController = rememberNavController()
     Scaffold {
-        AnimatedNavHost(
+        NavHost(
             navController = navController,
             startDestination = "auth",
             modifier = Modifier.fillMaxSize().padding(it)

--- a/app/src/main/java/com/boswelja/truemanager/MainActivity.kt
+++ b/app/src/main/java/com/boswelja/truemanager/MainActivity.kt
@@ -38,6 +38,7 @@ fun MainScreen() {
             modifier = Modifier.fillMaxSize().padding(it)
         ) {
             authNavigation(
+                navController,
                 "auth",
                 onLoginSuccess = {
                     navController.navigate("reporting") {

--- a/app/src/main/java/com/boswelja/truemanager/MainApplication.kt
+++ b/app/src/main/java/com/boswelja/truemanager/MainApplication.kt
@@ -2,7 +2,7 @@ package com.boswelja.truemanager
 
 import android.app.Application
 import com.boswelja.truemanager.auth.authModule
-import com.boswelja.truemanager.core.api.v2.apiV2Module
+import com.boswelja.truemanager.core.api.v2.ApiV2Module
 import com.boswelja.truemanager.reporting.reportingModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -14,7 +14,7 @@ class MainApplication : Application() {
 
         startKoin {
             androidContext(this@MainApplication)
-            modules(apiV2Module)
+            modules(ApiV2Module)
 
             modules(
                 authModule,

--- a/config/detekt.yml
+++ b/config/detekt.yml
@@ -98,7 +98,7 @@ complexity:
     active: true
     threshold: 4
   ComplexInterface:
-    active: true
+    active: false
     threshold: 10
     includeStaticDeclarations: false
     includePrivateDeclarations: false

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
@@ -24,7 +24,7 @@ import org.koin.dsl.module
  * A Koin module to inject the auth dependency graph. This depends on the API module.
  */
 @OptIn(ExperimentalSerializationApi::class)
-val apiV2Module = module {
+val ApiV2Module = module {
     // API state
     singleOf(::InMemoryApiStateProvider) bind ApiStateProvider::class
 

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
@@ -45,13 +45,12 @@ val apiV2Module = module {
                 })
             }
             defaultRequest {
-                apiStateProvider.authorization?.let { authorization ->
-                    when (authorization) {
-                        is Authorization.ApiKey -> bearerAuth(authorization.apiKey)
-                        is Authorization.Basic -> basicAuth(authorization.username, authorization.password)
-                    }
+                when (val authorization = requireNotNull(apiStateProvider.authorization)) {
+                    is Authorization.ApiKey -> bearerAuth(authorization.apiKey)
+                    is Authorization.Basic -> basicAuth(authorization.username, authorization.password)
                 }
-                apiStateProvider.serverAddress?.let { url(it) }
+                val baseUrl = requireNotNull(apiStateProvider.serverAddress)
+                url(baseUrl)
             }
         }
     }

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
@@ -7,6 +7,8 @@ import com.boswelja.truemanager.core.api.v2.auth.AuthV2Api
 import com.boswelja.truemanager.core.api.v2.auth.AuthV2ApiImpl
 import com.boswelja.truemanager.core.api.v2.reporting.ReportingV2Api
 import com.boswelja.truemanager.core.api.v2.reporting.ReportingV2ApiImpl
+import com.boswelja.truemanager.core.api.v2.system.SystemV2Api
+import com.boswelja.truemanager.core.api.v2.system.SystemV2ApiImpl
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -61,4 +63,5 @@ val ApiV2Module = module {
     singleOf(::ApiKeyV2ApiImpl) bind ApiKeyV2Api::class
     singleOf(::AuthV2ApiImpl) bind AuthV2Api::class
     singleOf(::ReportingV2ApiImpl) bind ReportingV2Api::class
+    singleOf(::SystemV2ApiImpl) bind SystemV2Api::class
 }

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/ApiV2Module.kt
@@ -20,6 +20,9 @@ import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
 import org.koin.dsl.module
 
+/**
+ * A Koin module to inject the auth dependency graph. This depends on the API module.
+ */
 @OptIn(ExperimentalSerializationApi::class)
 val apiV2Module = module {
     // API state

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/Exceptions.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/Exceptions.kt
@@ -4,9 +4,12 @@ import java.io.IOException
 
 /**
  * Thrown when an HTTP request returns a non-OK code.
+ *
+ * @property code The non-200 HTTP status code.
+ * @property description A human-readable description of the HTTP status.
  */
 class HttpsNotOkException(
-    code: Int,
-    description: String,
+    val code: Int,
+    val description: String,
     cause: Throwable? = null
 ) : IOException(description, cause)

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/Exceptions.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/Exceptions.kt
@@ -1,0 +1,12 @@
+package com.boswelja.truemanager.core.api.v2
+
+import java.io.IOException
+
+/**
+ * Thrown when an HTTP request returns a non-OK code.
+ */
+class HttpsNotOkException(
+    code: Int,
+    description: String,
+    cause: Throwable? = null
+) : IOException(description, cause)

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/HttpsNotOkException.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/HttpsNotOkException.kt
@@ -7,6 +7,8 @@ import java.io.IOException
  *
  * @property code The non-200 HTTP status code.
  * @property description A human-readable description of the HTTP status.
+ * @param cause The cause (which is saved for later retrieval by the getCause() method). (A null
+ * value is permitted, and indicates that the cause is nonexistent or unknown.)
  */
 class HttpsNotOkException(
     val code: Int,

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/apikey/ApiKeyV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/apikey/ApiKeyV2ApiImpl.kt
@@ -1,5 +1,6 @@
 package com.boswelja.truemanager.core.api.v2.apikey
 
+import com.boswelja.truemanager.core.api.v2.HttpsNotOkException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -9,6 +10,7 @@ import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
@@ -38,6 +40,9 @@ internal class ApiKeyV2ApiImpl(
         val response = client.post("api_key") {
             contentType(ContentType.Application.Json)
             setBody(CreateApiKeyBody(name, listOf(CreateApiKeyBody.ApiKeyAllowItem("*", "*"))))
+        }
+        if (response.status != HttpStatusCode.OK) {
+            throw HttpsNotOkException(response.status.value, response.status.description)
         }
         val dto: ApiKeyDto = response.body()
         return requireNotNull(dto.key)

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/apikey/ApiKeyV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/apikey/ApiKeyV2ApiImpl.kt
@@ -37,7 +37,7 @@ internal class ApiKeyV2ApiImpl(
     override suspend fun create(name: String): String {
         val response = client.post("api_key") {
             contentType(ContentType.Application.Json)
-            setBody(CreateApiKeyBody(name))
+            setBody(CreateApiKeyBody(name, listOf(CreateApiKeyBody.ApiKeyAllowItem("*", "*"))))
         }
         val dto: ApiKeyDto = response.body()
         return requireNotNull(dto.key)
@@ -106,8 +106,18 @@ internal data class ApiKeyDto(
 @Serializable
 internal data class CreateApiKeyBody(
     @SerialName("name")
-    val name: String
-)
+    val name: String,
+    @SerialName("allowlist")
+    val allowList: List<ApiKeyAllowItem>
+) {
+    @Serializable
+    internal data class ApiKeyAllowItem(
+        @SerialName("method")
+        val method: String,
+        @SerialName("resource")
+        val resource: String,
+    )
+}
 
 @Serializable
 internal data class UpdateApiKeyBody(

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/auth/AuthV2Api.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/auth/AuthV2Api.kt
@@ -2,6 +2,10 @@ package com.boswelja.truemanager.core.api.v2.auth
 
 import kotlin.time.Duration
 
+/**
+ * Describes the TrueNAS API V2 "Auth" group. Note these mappings may not be 1:1, as we will
+ * rearrange data to be more accessible in Kotlin.
+ */
 interface AuthV2Api {
 
     /**
@@ -32,5 +36,5 @@ interface AuthV2Api {
     /**
      * Checks whether two-factor-authentication is required to connect to the server.
      */
-    suspend fun twoFactorAuth(): Boolean
+    suspend fun isTwoFactorEnabled(): Boolean
 }

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/auth/AuthV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/auth/AuthV2ApiImpl.kt
@@ -21,7 +21,6 @@ internal class AuthV2ApiImpl(
         val response = client.post("auth/check_password") {
             contentType(ContentType.Application.Json)
             setBody(UserCredentialsDto(username, password))
-            basicAuth(username, password)
         }
         return response.status == HttpStatusCode.OK
     }
@@ -30,7 +29,6 @@ internal class AuthV2ApiImpl(
         val response = client.post("auth/check_user") {
             contentType(ContentType.Application.Json)
             setBody(UserCredentialsDto(username, password))
-            basicAuth(username, password)
         }
         return response.status == HttpStatusCode.OK
     }
@@ -44,7 +42,6 @@ internal class AuthV2ApiImpl(
         val response = client.post("auth/generate_token") {
             contentType(ContentType.Application.Json)
             setBody(SessionTokenRequestDto(timeToLive.inWholeSeconds, JsonObject(emptyMap()), matchOrigin))
-            basicAuth(username, password)
         }
         if (response.status != HttpStatusCode.OK) {
             error(response.body())
@@ -60,7 +57,7 @@ internal class AuthV2ApiImpl(
         return response.body()
     }
 
-    override suspend fun twoFactorAuth(): Boolean {
+    override suspend fun isTwoFactorEnabled(): Boolean {
         val response = client.get("auth/two_factor_auth")
         return response.body()
     }

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/auth/AuthV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/auth/AuthV2ApiImpl.kt
@@ -2,7 +2,6 @@ package com.boswelja.truemanager.core.api.v2.auth
 
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.request.basicAuth
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
@@ -1,0 +1,190 @@
+package com.boswelja.truemanager.core.api.v2.system
+
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlin.time.Duration
+
+/**
+ * Describes the TrueNAS API V2 "System" group. Note these mappings may not be 1:1, as we will
+ * rearrange data to be more accessible in Kotlin.
+ */
+@Suppress("TooManyFunctions")
+interface SystemV2Api {
+
+    /**
+     * Get a unique identifier that will be reset on each system reboot.
+     */
+    fun getBootId(): String
+
+    /**
+     * Get the environment in which product is running.
+     */
+    fun getEnvironment(): Environment
+
+    /**
+     * Get whether the given feature is enabled.
+     */
+    fun isFeatureEnabled(featureName: String): Boolean
+
+    /**
+     * Get a hex string that is generated based on the contents of the /etc/hostid file. This is a
+     * permanent value that persists across reboots/upgrades and can be used as a unique identifier
+     * for the machine.
+     */
+    fun getHostId(): String
+
+    /**
+     * Get basic system information.
+     */
+    fun getSystemInfo(): SystemInfo
+
+    /**
+     * Get whether the system is currently running a stable build.
+     */
+    fun isStable(): Boolean
+
+    /**
+     * Update license file.
+     */
+    fun updateLicense(license: String)
+
+    /**
+     * Get the name of the product the system is using. FOr example, "TrueNAS".
+     */
+    fun getProductName(): String
+
+    /**
+     * Get the type of product the system is using. For example, "SCALE"
+     */
+    fun getProductType(): String
+
+    /**
+     * Get whether the system is booted and ready to use.
+     */
+    fun isReady(): Boolean
+
+    /**
+     * Reboot the system.
+     */
+    fun reboot()
+
+    /**
+     * Shutdown the system.
+     */
+    fun shutdown()
+
+    /**
+     * Get the current system state.
+     */
+    fun getState(): State
+
+    /**
+     * Get the version of the product this system is using. For example, "TrueNAS-SCALE-22.12.2".
+     */
+    fun getVersion(): String
+
+    /**
+     * Get a shortened version of the product this system is using. For example, "22.12.2".
+     */
+    fun getShortVersion(): String
+}
+
+/**
+ * Possible host environment types for a system.
+ */
+enum class Environment {
+    /**
+     * This system is hosted on standard hardware.
+     */
+    DEFAULT,
+
+    /**
+     * This system is hosted on Amazon Web Services (AWS) EC2.
+     */
+    EC2
+}
+
+/**
+ * Possible system states.
+ */
+enum class State {
+    /**
+     * The system is currently booting. It will be unusable until boot has completed.
+     */
+    BOOTING,
+
+    /**
+     * The system is running and ready to use.
+     */
+    READY,
+
+    /**
+     * The system is shutting down and is unusable.
+     */
+    SHUTTING_DOWN
+}
+
+/**
+ * Basic system information.
+ *
+ * @property version The full version of the product this system is running. See [SystemV2Api.getVersion].
+ * @property buildTime The time that the systems product version was built.
+ * @property hostname The systems host name. It should be identifiable on the local network via this.
+ * @property physicalMemoryBytes The amount of physical memory the system has, in Bytes.
+ * @property cpuInfo Information about the systems CPU configuration.
+ * @property uptime The amount of time the system has been running for.
+ * @property license The systems license file, or null if not present.
+ * @property bootTime The time this system was last booted.
+ * @property birthday The systems birthday.
+ * @property timezone The system time zone.
+ * @property hasEccMemory Whether the server has ECC memory.
+ * @property hostInfo Information about the systems host hardware.
+ */
+data class SystemInfo(
+    val version: String,
+    val buildTime: Instant,
+    val hostname: String,
+    val physicalMemoryBytes: Long,
+    val cpuInfo: CpuInfo,
+    val uptime: Duration,
+    val license: String?,
+    val bootTime: Instant,
+    val birthday: LocalDate,
+    val timezone: TimeZone,
+    val hasEccMemory: Boolean,
+    val hostInfo: HostInfo
+) {
+    /**
+     * Information about a CPU.
+     *
+     * @property model The model name of the CPU.
+     * @property physicalCores The number of physical cores and threads the CPU has.
+     * @property totalCores The total number of cores this CPU configuration has.
+     */
+    data class CpuInfo(
+        val model: String,
+        val physicalCores: Int,
+        val totalCores: Int,
+    ) {
+        /**
+         * The number of NUMA nodes this COU configuration has.
+         */
+        val numaNodes: Int = totalCores / physicalCores
+    }
+
+    /**
+     * Information about host hardware for a system.
+     *
+     * @property serial The hardware serial number. This should match the OEM serial number.
+     * @property product The name of the hardware that is running the system, for example "ProLiant DL380 Gen9".
+     * @property productVersion The hardware configuration version.
+     * @property manufacturer The hardware manufacturer, for example "HP".
+     */
+    data class HostInfo(
+        val serial: String,
+        val product: String,
+        val productVersion: String?,
+        val manufacturer: String
+    )
+}

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
@@ -15,79 +15,79 @@ interface SystemV2Api {
     /**
      * Get a unique identifier that will be reset on each system reboot.
      */
-    fun getBootId(): String
+    suspend fun getBootId(): String
 
     /**
      * Get the environment in which product is running.
      */
-    fun getEnvironment(): Environment
+    suspend fun getEnvironment(): Environment
 
     /**
      * Get whether the given feature is enabled.
      */
-    fun isFeatureEnabled(featureName: String): Boolean
+    suspend fun isFeatureEnabled(featureName: String): Boolean
 
     /**
      * Get a hex string that is generated based on the contents of the /etc/hostid file. This is a
      * permanent value that persists across reboots/upgrades and can be used as a unique identifier
      * for the machine.
      */
-    fun getHostId(): String
+    suspend fun getHostId(): String
 
     /**
      * Get basic system information.
      */
-    fun getSystemInfo(): SystemInfo
+    suspend fun getSystemInfo(): SystemInfo
 
     /**
      * Get whether the system is currently running a stable build.
      */
-    fun isStable(): Boolean
+    suspend fun isStable(): Boolean
 
     /**
      * Update license file.
      */
-    fun updateLicense(license: String)
+    suspend fun updateLicense(license: String)
 
     /**
      * Get the name of the product the system is using. FOr example, "TrueNAS".
      */
-    fun getProductName(): String
+    suspend fun getProductName(): String
 
     /**
      * Get the type of product the system is using. For example, "SCALE"
      */
-    fun getProductType(): String
+    suspend fun getProductType(): String
 
     /**
      * Get whether the system is booted and ready to use.
      */
-    fun isReady(): Boolean
+    suspend fun isReady(): Boolean
 
     /**
      * Reboot the system.
      */
-    fun reboot()
+    suspend fun reboot()
 
     /**
      * Shutdown the system.
      */
-    fun shutdown()
+    suspend fun shutdown()
 
     /**
      * Get the current system state.
      */
-    fun getState(): State
+    suspend fun getState(): State
 
     /**
      * Get the version of the product this system is using. For example, "TrueNAS-SCALE-22.12.2".
      */
-    fun getVersion(): String
+    suspend fun getVersion(): String
 
     /**
      * Get a shortened version of the product this system is using. For example, "22.12.2".
      */
-    fun getShortVersion(): String
+    suspend fun getShortVersion(): String
 }
 
 /**

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
@@ -150,7 +150,7 @@ data class SystemInfo(
     val uptime: Duration,
     val license: String?,
     val bootTime: Instant,
-    val birthday: LocalDate,
+    val birthday: Instant?,
     val timezone: TimeZone,
     val hasEccMemory: Boolean,
     val hostInfo: HostInfo

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2Api.kt
@@ -1,7 +1,6 @@
 package com.boswelja.truemanager.core.api.v2.system
 
 import kotlinx.datetime.Instant
-import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlin.time.Duration
 

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
@@ -1,0 +1,89 @@
+package com.boswelja.truemanager.core.api.v2.system
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+
+internal class SystemV2ApiImpl(
+    private val httpClient: HttpClient
+) : SystemV2Api {
+    override suspend fun getBootId(): String {
+        val response = httpClient.get("systen/boot_id")
+        return response.body()
+    }
+
+    override suspend fun getEnvironment(): Environment {
+        val response = httpClient.get("systen/boot_id")
+        return when (val environmentDto: String = response.body()) {
+            "DEFAULT" -> Environment.DEFAULT
+            "EC2" -> Environment.EC2
+            else -> error("Unknown environment '$environmentDto'")
+        }
+    }
+
+    override suspend fun isFeatureEnabled(featureName: String): Boolean {
+        val response = httpClient.post("systen/feature_enabled") {
+            setBody(featureName)
+        }
+        return response.body()
+    }
+
+    override suspend fun getHostId(): String {
+        val response = httpClient.get("system/host_id")
+        return response.body()
+    }
+
+    override suspend fun getSystemInfo(): SystemInfo {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun isStable(): Boolean {
+        val response = httpClient.get("system/is_stable")
+        return response.body()
+    }
+
+    override suspend fun updateLicense(license: String) {
+        httpClient.post("systen/license_update") {
+            setBody(license)
+        }
+    }
+
+    override suspend fun getProductName(): String {
+        val response = httpClient.get("system/product_name")
+        return response.body()
+    }
+
+    override suspend fun getProductType(): String {
+        val response = httpClient.get("system/product_type")
+        return response.body()
+    }
+
+    override suspend fun isReady(): Boolean {
+        val response = httpClient.get("system/ready")
+        return response.body()
+    }
+
+    override suspend fun reboot() {
+        httpClient.post("system/reboot")
+    }
+
+    override suspend fun shutdown() {
+        httpClient.post("system/shutdown")
+    }
+
+    override suspend fun getState(): State {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getVersion(): String {
+        val response = httpClient.get("system/version")
+        return response.body()
+    }
+
+    override suspend fun getShortVersion(): String {
+        val response = httpClient.get("system/version_short")
+        return response.body()
+    }
+}

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
@@ -5,6 +5,11 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlin.time.Duration.Companion.seconds
 
 internal class SystemV2ApiImpl(
     private val httpClient: HttpClient
@@ -36,7 +41,31 @@ internal class SystemV2ApiImpl(
     }
 
     override suspend fun getSystemInfo(): SystemInfo {
-        TODO("Not yet implemented")
+        val response = httpClient.get("system/info")
+        val infoDto: SystemInfoDto = response.body()
+        return SystemInfo(
+            version = infoDto.version,
+            buildTime = Instant.fromEpochMilliseconds(infoDto.buildTime.date),
+            hostname = infoDto.hostName,
+            physicalMemoryBytes = infoDto.physicalMemory,
+            cpuInfo = SystemInfo.CpuInfo(
+                model = infoDto.cpuModel,
+                physicalCores = infoDto.physicalCores,
+                totalCores = infoDto.cores
+            ),
+            uptime = infoDto.uptimeSeconds.seconds,
+            license = infoDto.license,
+            bootTime = Instant.fromEpochMilliseconds(infoDto.bootTime.date),
+            birthday = infoDto.birthday?.let { Instant.fromEpochMilliseconds(it.date) },
+            timezone = TimeZone.of(infoDto.timeZone),
+            hasEccMemory = infoDto.eccMemory,
+            hostInfo = SystemInfo.HostInfo(
+                serial = infoDto.systemSerial,
+                product = infoDto.systemProduct,
+                productVersion = infoDto.systemProductVersion,
+                manufacturer = infoDto.systemManufacturer
+            )
+        )
     }
 
     override suspend fun isStable(): Boolean {
@@ -74,7 +103,12 @@ internal class SystemV2ApiImpl(
     }
 
     override suspend fun getState(): State {
-        TODO("Not yet implemented")
+        val response = httpClient.get("system/state")
+        return when (response.body<StateDto>()) {
+            StateDto.BOOTING -> State.BOOTING
+            StateDto.READY -> State.READY
+            StateDto.SHUTTING_DOWN -> State.SHUTTING_DOWN
+        }
     }
 
     override suspend fun getVersion(): String {
@@ -86,4 +120,65 @@ internal class SystemV2ApiImpl(
         val response = httpClient.get("system/version_short")
         return response.body()
     }
+}
+
+@Serializable
+internal enum class StateDto {
+    @SerialName("BOOTING")
+    BOOTING,
+    @SerialName("READY")
+    READY,
+    @SerialName("SHUTTING_DOWN")
+    SHUTTING_DOWN
+}
+
+@Serializable
+internal data class SystemInfoDto(
+    @SerialName("version")
+    val version: String,
+    @SerialName("buildtime")
+    val buildTime: DateDto,
+    @SerialName("hostname")
+    val hostName: String,
+    @SerialName("physmem")
+    val physicalMemory: Long,
+    @SerialName("model")
+    val cpuModel: String,
+    @SerialName("cores")
+    val cores: Int,
+    @SerialName("physical_cores")
+    val physicalCores: Int,
+    @SerialName("loadavg")
+    val loadAvg: List<Int>,
+    @SerialName("uptime")
+    val uptime: String,
+    @SerialName("uptime_seconds")
+    val uptimeSeconds: Double,
+    @SerialName("system_serial")
+    val systemSerial: String,
+    @SerialName("system_product")
+    val systemProduct: String,
+    @SerialName("system_product_version")
+    val systemProductVersion: String,
+    @SerialName("license")
+    val license: String?,
+    @SerialName("boottime")
+    val bootTime: DateDto,
+    @SerialName("datetime")
+    val dateTime: DateDto,
+    @SerialName("birthday")
+    val birthday: DateDto?,
+    @SerialName("timezone")
+    val timeZone: String,
+    @SerialName("system_manufacturer")
+    val systemManufacturer: String,
+    @SerialName("ecc_memory")
+    val eccMemory: Boolean
+) {
+
+    @Serializable
+    internal data class DateDto(
+        @SerialName("\$date")
+        val date: Long
+    )
 }

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
@@ -11,7 +11,6 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
 internal class SystemV2ApiImpl(

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
@@ -149,7 +149,7 @@ internal data class SystemInfoDto(
     @SerialName("physical_cores")
     val physicalCores: Int,
     @SerialName("loadavg")
-    val loadAvg: List<Int>,
+    val loadAvg: List<Double>,
     @SerialName("uptime")
     val uptime: String,
     @SerialName("uptime_seconds")

--- a/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
+++ b/core/api/src/main/kotlin/com/boswelja/truemanager/core/api/v2/system/SystemV2ApiImpl.kt
@@ -1,14 +1,17 @@
 package com.boswelja.truemanager.core.api.v2.system
 
+import com.boswelja.truemanager.core.api.v2.HttpsNotOkException
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.http.HttpStatusCode
 import kotlinx.datetime.Instant
 import kotlinx.datetime.TimeZone
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import java.io.IOException
 import kotlin.time.Duration.Companion.seconds
 
 internal class SystemV2ApiImpl(
@@ -42,6 +45,9 @@ internal class SystemV2ApiImpl(
 
     override suspend fun getSystemInfo(): SystemInfo {
         val response = httpClient.get("system/info")
+        if (response.status != HttpStatusCode.OK) {
+            throw HttpsNotOkException(response.status.value, response.status.description)
+        }
         val infoDto: SystemInfoDto = response.body()
         return SystemInfo(
             version = infoDto.version,

--- a/features/auth/build.gradle.kts
+++ b/features/auth/build.gradle.kts
@@ -59,9 +59,8 @@ dependencies {
     ksp(libs.room.compiler)
 
     // Compose
-    implementation(libs.accompanist.navigation)
+    implementation(libs.androidx.navigation)
     implementation(libs.accompanist.drawablepainter)
-    implementation(platform(libs.compose.bom))
     implementation(libs.bundles.compose)
     debugImplementation(libs.bundles.compose.tooling)
 

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/DI.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/DI.kt
@@ -2,7 +2,7 @@ package com.boswelja.truemanager.auth
 
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStore
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStoreImpl
-import com.boswelja.truemanager.auth.ui.AuthViewModel
+import com.boswelja.truemanager.auth.ui.addserver.AddServerViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -11,5 +11,5 @@ import org.koin.dsl.module
 val authModule = module {
     singleOf(::AuthenticatedServersStoreImpl) bind AuthenticatedServersStore::class
 
-    viewModelOf(::AuthViewModel)
+    viewModelOf(::AddServerViewModel)
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/DI.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/DI.kt
@@ -3,6 +3,7 @@ package com.boswelja.truemanager.auth
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStore
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStoreImpl
 import com.boswelja.truemanager.auth.ui.addserver.AddServerViewModel
+import com.boswelja.truemanager.auth.ui.serverselect.SelectServerViewModel
 import org.koin.androidx.viewmodel.dsl.viewModelOf
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.bind
@@ -12,4 +13,5 @@ val authModule = module {
     singleOf(::AuthenticatedServersStoreImpl) bind AuthenticatedServersStore::class
 
     viewModelOf(::AddServerViewModel)
+    viewModelOf(::SelectServerViewModel)
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/serverstore/AuthenticatedServersStore.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/serverstore/AuthenticatedServersStore.kt
@@ -22,15 +22,19 @@ interface AuthenticatedServersStore {
     /**
      * Add a new server to the authentication store.
      */
-    suspend fun add(serverAddress: String, token: String)
+    suspend fun add(server: AuthenticatedServer)
 }
 
 /**
  * Details for a server that has been previously authenticated.
+ * @property uid A unique identifier for this server.
  * @property serverAddress The URL of the server. Note this is different from the URL for the API.
  * @property token The bearer token used to access the server. This may or may not still be valid.
+ * @property name A friendly name for the server.
  */
 data class AuthenticatedServer(
+    val uid: String,
     val serverAddress: String,
     val token: String,
+    val name: String,
 )

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/serverstore/AuthenticatedServersStore.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/serverstore/AuthenticatedServersStore.kt
@@ -2,15 +2,34 @@ package com.boswelja.truemanager.auth.serverstore
 
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * A repository for storing servers that we have previously authenticated with. Note that an entry
+ * stored here doesn't mean we are still authenticated, since the token may have been revoked or
+ * expired.
+ */
 interface AuthenticatedServersStore {
 
+    /**
+     * Flow a list of all [AuthenticatedServer]s.
+     */
     fun getAll(): Flow<List<AuthenticatedServer>>
 
+    /**
+     * Delete an [AuthenticatedServer] from the store.
+     */
     suspend fun delete(server: AuthenticatedServer)
 
+    /**
+     * Add a new server to the authentication store.
+     */
     suspend fun add(serverAddress: String, token: String)
 }
 
+/**
+ * Details for a server that has been previously authenticated.
+ * @property serverAddress The URL of the server. Note this is different from the URL for the API.
+ * @property token The bearer token used to access the server. This may or may not still be valid.
+ */
 data class AuthenticatedServer(
     val serverAddress: String,
     val token: String,

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/serverstore/AuthenticatedServersStoreImpl.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/serverstore/AuthenticatedServersStoreImpl.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapLatest
 
-class AuthenticatedServersStoreImpl(
+internal class AuthenticatedServersStoreImpl(
     context: Context
 ) : AuthenticatedServersStore {
 
@@ -44,7 +44,7 @@ class AuthenticatedServersStoreImpl(
 }
 
 @Entity(tableName = "authenticated_servers")
-data class AuthenticatedServerDto(
+internal data class AuthenticatedServerDto(
     @ColumnInfo(name = "server_address")
     val serverAddress: String,
     @PrimaryKey
@@ -53,7 +53,7 @@ data class AuthenticatedServerDto(
 )
 
 @Dao
-interface AuthenticatedServerDao {
+internal interface AuthenticatedServerDao {
     @Query("SELECT * FROM authenticated_servers")
     fun getAll(): Flow<List<AuthenticatedServerDto>>
 
@@ -65,6 +65,6 @@ interface AuthenticatedServerDao {
 }
 
 @Database(entities = [AuthenticatedServerDto::class], version = 1)
-abstract class AuthenticatedServerDatabase : RoomDatabase() {
+internal abstract class AuthenticatedServerDatabase : RoomDatabase() {
     abstract fun authenticatedServerDao(): AuthenticatedServerDao
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/Navigation.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/Navigation.kt
@@ -1,22 +1,16 @@
 package com.boswelja.truemanager.auth.ui
 
-import androidx.compose.animation.ExperimentalAnimationApi
-import androidx.compose.animation.fadeIn
-import androidx.compose.animation.fadeOut
-import androidx.compose.animation.slideInHorizontally
-import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
 import com.boswelja.truemanager.auth.ui.addserver.AuthScreen
 import com.boswelja.truemanager.auth.ui.serverselect.SelectServerScreen
-import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.navigation.animation.navigation
 
-@OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.authNavigation(
     navController: NavHostController,
     route: String,
@@ -24,11 +18,7 @@ fun NavGraphBuilder.authNavigation(
 ) {
     navigation(
         startDestination = "picker",
-        route = route,
-        enterTransition = { slideInHorizontally { it / 2 } + fadeIn() },
-        exitTransition = { slideOutHorizontally() + fadeOut() },
-        popEnterTransition = { slideInHorizontally() + fadeIn() },
-        popExitTransition = { slideOutHorizontally { it / 2 } + fadeOut() }
+        route = route
     ) {
         composable("login") {
             AuthScreen(

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/Navigation.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/Navigation.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
+import com.boswelja.truemanager.auth.ui.addserver.AuthScreen
 import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.navigation
 
@@ -24,6 +25,9 @@ fun NavGraphBuilder.authNavigation(
                 Modifier.fillMaxSize(),
                 PaddingValues(32.dp)
             )
+        }
+        composable("picker") {
+
         }
     }
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/Navigation.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/Navigation.kt
@@ -1,33 +1,51 @@
 package com.boswelja.truemanager.auth.ui
 
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import com.boswelja.truemanager.auth.ui.addserver.AuthScreen
+import com.boswelja.truemanager.auth.ui.serverselect.SelectServerScreen
 import com.google.accompanist.navigation.animation.composable
 import com.google.accompanist.navigation.animation.navigation
 
 @OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.authNavigation(
+    navController: NavHostController,
     route: String,
     onLoginSuccess: () -> Unit
 ) {
     navigation(
-        startDestination = "login",
-        route = route
+        startDestination = "picker",
+        route = route,
+        enterTransition = { slideInHorizontally { it / 2 } + fadeIn() },
+        exitTransition = { slideOutHorizontally() + fadeOut() },
+        popEnterTransition = { slideInHorizontally() + fadeIn() },
+        popExitTransition = { slideOutHorizontally { it / 2 } + fadeOut() }
     ) {
         composable("login") {
             AuthScreen(
-                onLoginSuccess,
-                Modifier.fillMaxSize(),
-                PaddingValues(32.dp)
+                onLoginSuccess = onLoginSuccess,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(32.dp)
             )
         }
         composable("picker") {
-
+            SelectServerScreen(
+                onLoginSuccess = onLoginSuccess,
+                onAddServer = {
+                    navController.navigate("login")
+                },
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(32.dp)
+            )
         }
     }
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
@@ -1,4 +1,4 @@
-package com.boswelja.truemanager.auth.ui
+package com.boswelja.truemanager.auth.ui.addserver
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -7,12 +7,10 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.with
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -23,7 +21,6 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -61,7 +58,7 @@ fun AuthComponents(
     onLoginSuccess: () -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
-    viewModel: AuthViewModel = koinViewModel()
+    viewModel: AddServerViewModel = koinViewModel()
 ) {
     val layoutDirection = LocalLayoutDirection.current
     val isLoading by viewModel.isLoading.collectAsState()

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import com.boswelja.truemanager.auth.R
 import com.boswelja.truemanager.core.api.v2.ApiStateProvider
+import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.rememberKoinInject
 
@@ -87,10 +88,16 @@ fun AuthComponents(
     }
 
     // TODO handle login properly
-    val apiStateProvider: ApiStateProvider = rememberKoinInject()
-    LaunchedEffect(isLoading) {
-        if (!isLoading && apiStateProvider.authorization != null) {
-            onLoginSuccess()
+    LaunchedEffect(viewModel) {
+        viewModel.events.collectLatest {
+            when (it) {
+                AddServerViewModel.Event.LoginSuccess -> onLoginSuccess()
+                AddServerViewModel.Event.LoginFailedServerNotFound -> TODO()
+                AddServerViewModel.Event.LoginFailedKeyInvalid -> TODO()
+                AddServerViewModel.Event.LoginFailedUsernameOrPasswordInvalid -> TODO()
+                null -> return@collectLatest
+            }
+            viewModel.clearPendingEvent()
         }
     }
 

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
@@ -19,9 +19,9 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Dns
+import androidx.compose.material.icons.filled.Label
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Tab
 import androidx.compose.material3.TabRow
@@ -50,7 +50,6 @@ import com.boswelja.truemanager.core.api.v2.ApiStateProvider
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.rememberKoinInject
 
-
 @Composable
 fun AuthComponents(
     onLoginSuccess: () -> Unit,
@@ -61,6 +60,7 @@ fun AuthComponents(
     val layoutDirection = LocalLayoutDirection.current
     val isLoading by viewModel.isLoading.collectAsState()
 
+    var serverName by rememberSaveable { mutableStateOf("") }
     var serverAddress by rememberSaveable { mutableStateOf("") }
     var selectedAuthType by rememberSaveable(saver = rememberAuthTypeSaver()) {
         mutableStateOf(AuthTypes.first())
@@ -72,8 +72,8 @@ fun AuthComponents(
 
     val logIn = {
         when (selectedAuthType) {
-            AuthType.ApiKeyAuth -> viewModel.tryLogIn(serverAddress, apiKey)
-            AuthType.BasicAuth -> viewModel.tryLogIn(serverAddress, username, password)
+            AuthType.ApiKeyAuth -> viewModel.tryLogIn(serverName, serverAddress, apiKey)
+            AuthType.BasicAuth -> viewModel.tryLogIn(serverName, serverAddress, username, password)
         }
     }
     val loginEnabled by remember {
@@ -98,6 +98,20 @@ fun AuthComponents(
         modifier = modifier,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        ServerNameField(
+            serverName = serverName,
+            onServerNameChange = { serverName = it },
+            enabled = !isLoading,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    top = contentPadding.calculateTopPadding(),
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection)
+                )
+                .widthIn(max = 560.dp)
+        )
+        Spacer(Modifier.height(8.dp))
         ServerAddressField(
             serverAddress = serverAddress,
             onServerAddressChange = { serverAddress = it },
@@ -105,7 +119,6 @@ fun AuthComponents(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(
-                    top = contentPadding.calculateTopPadding(),
                     start = contentPadding.calculateStartPadding(layoutDirection),
                     end = contentPadding.calculateEndPadding(layoutDirection)
                 )
@@ -164,6 +177,28 @@ fun AuthComponents(
             )
         }
     }
+}
+
+@Composable
+fun ServerNameField(
+    serverName: String,
+    onServerNameChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean
+) {
+    TextField(
+        value = serverName,
+        onValueChange = onServerNameChange,
+        label = { Text("Server Name (Optional)") },
+        leadingIcon = { Icon(Icons.Default.Label, contentDescription = null) },
+        keyboardOptions = KeyboardOptions(
+            keyboardType = KeyboardType.Text,
+            imeAction = ImeAction.Next
+        ),
+        singleLine = true,
+        enabled = enabled,
+        modifier = modifier
+    )
 }
 
 @Composable

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
@@ -1,10 +1,9 @@
 package com.boswelja.truemanager.auth.ui.addserver
 
 import androidx.compose.animation.AnimatedContent
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
-import androidx.compose.animation.with
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -52,7 +51,6 @@ import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.rememberKoinInject
 
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 fun AuthComponents(
     onLoginSuccess: () -> Unit,
@@ -132,7 +130,7 @@ fun AuthComponents(
             AnimatedContent(
                 targetState = selectedAuthType,
                 label = "Login method content",
-                transitionSpec = { fadeIn() with fadeOut() },
+                transitionSpec = { fadeIn() togetherWith fadeOut() },
             ) { authType ->
                 when (authType) {
                     AuthType.ApiKeyAuth -> {
@@ -168,7 +166,6 @@ fun AuthComponents(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ServerAddressField(
     serverAddress: String,
@@ -216,7 +213,6 @@ fun AuthTypeSelector(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun BasicAuthFields(
     username: String,
@@ -265,7 +261,6 @@ fun BasicAuthFields(
     }
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ApiKeyFields(
     apiKey: String,

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerComponents.kt
@@ -114,6 +114,7 @@ fun AuthComponents(
                     isApiKeyInvalid = true
                 AddServerViewModel.Event.LoginFailedUsernameOrPasswordInvalid ->
                     isUsernameOrPasswordInvalid = true
+                AddServerViewModel.Event.LoginFailedKeyAlreadyExists -> TODO()
                 null -> return@collectLatest
             }
             viewModel.clearPendingEvent()

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerScreen.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerScreen.kt
@@ -1,34 +1,15 @@
 package com.boswelja.truemanager.auth.ui.addserver
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.withStyle
-import androidx.compose.ui.unit.dp
-import com.boswelja.truemanager.auth.R
-import com.google.accompanist.drawablepainter.rememberDrawablePainter
+import com.boswelja.truemanager.auth.ui.common.AuthHeader
 
 @Composable
 fun AuthScreen(
@@ -49,44 +30,4 @@ fun AuthScreen(
         )
         AuthComponents(onLoginSuccess, Modifier.fillMaxSize(), contentPadding)
     }
-}
-
-@Composable
-fun AuthHeader(
-    modifier: Modifier = Modifier
-) {
-    Surface(color = MaterialTheme.colorScheme.primaryContainer) {
-        Box(
-            modifier = modifier,
-            contentAlignment = Alignment.Center
-        ) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Image(painter = rememberAppIconPainter(), contentDescription = null)
-                Spacer(Modifier.width(16.dp))
-                Column {
-                    Text(
-                        text = buildAnnotatedString {
-                            append(stringResource(R.string.auth_header_true))
-                            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
-                                append(stringResource(R.string.auth_header_manager))
-                            }
-                        },
-                        style = MaterialTheme.typography.headlineLarge
-                    )
-                    Text(
-                        text = stringResource(R.string.auth_header_label),
-                        style = MaterialTheme.typography.labelLarge,
-                        modifier = Modifier.padding(start = 4.dp)
-                    )
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun rememberAppIconPainter(): Painter {
-    val context = LocalContext.current
-    val icon = remember(context) { context.packageManager.getApplicationIcon(context.packageName) }
-    return rememberDrawablePainter(drawable = icon)
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerScreen.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerScreen.kt
@@ -1,4 +1,4 @@
-package com.boswelja.truemanager.auth.ui
+package com.boswelja.truemanager.auth.ui.addserver
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
@@ -8,6 +8,7 @@ import com.boswelja.truemanager.core.api.v2.ApiStateProvider
 import com.boswelja.truemanager.core.api.v2.Authorization
 import com.boswelja.truemanager.core.api.v2.apikey.ApiKeyV2Api
 import com.boswelja.truemanager.core.api.v2.auth.AuthV2Api
+import com.boswelja.truemanager.core.api.v2.system.SystemV2Api
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +18,7 @@ class AddServerViewModel(
     private val apiStateProvider: ApiStateProvider,
     private val authV2Api: AuthV2Api,
     private val apiKeyV2Api: ApiKeyV2Api,
+    private val systemV2Api: SystemV2Api,
     private val authedServersStore: AuthenticatedServersStore,
 ) : ViewModel() {
 
@@ -36,9 +38,11 @@ class AddServerViewModel(
             if (isValid) {
                 apiStateProvider.authorization = Authorization.Basic(username, password)
                 val apiKey = apiKeyV2Api.create("TrueManager for TrueNAS")
+
+                val uid = systemV2Api.getHostId()
                 authedServersStore.add(
                     AuthenticatedServer(
-                        uid = "TODO",
+                        uid = uid,
                         serverAddress = serverAddress,
                         token = apiKey,
                         name = serverName

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
@@ -1,4 +1,4 @@
-package com.boswelja.truemanager.auth.ui
+package com.boswelja.truemanager.auth.ui.addserver
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -12,7 +12,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 
-class AuthViewModel(
+class AddServerViewModel(
     private val apiStateProvider: ApiStateProvider,
     private val authV2Api: AuthV2Api,
     private val apiKeyV2Api: ApiKeyV2Api,

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
@@ -30,7 +30,8 @@ class AddServerViewModel(
             if (isValid) {
                 apiStateProvider.authorization = Authorization.Basic(username, password)
                 val apiKey = apiKeyV2Api.create("TrueManager for TrueNAS")
-                authedServersStore.add(serverAddress, apiKey)
+                // TODO
+                // authedServersStore.add(serverAddress, apiKey)
                 apiStateProvider.authorization = Authorization.ApiKey(apiKey)
             }
             _isLoading.value = false

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
@@ -1,6 +1,5 @@
 package com.boswelja.truemanager.auth.ui.addserver
 
-import android.os.strictmode.CleartextNetworkViolation
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -20,6 +19,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import java.io.IOException
 
+/**
+ * Responsible for exposing data to and handling events from the "add server" UI.
+ */
 class AddServerViewModel(
     private val apiStateProvider: ApiStateProvider,
     private val authV2Api: AuthV2Api,
@@ -29,18 +31,41 @@ class AddServerViewModel(
 ) : ViewModel() {
 
     private val _isLoading = MutableStateFlow(false)
+
+    /**
+     * Whether the ViewModel is currently loading data. This should be used to switch the UI to a
+     * loading state.
+     */
     val isLoading: StateFlow<Boolean> = _isLoading
 
     private val _events = MutableSharedFlow<Event?>(
         replay = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
+
+    /**
+     * Flows [Event]s coming from the ViewModel. If the value is null, there is no event to handle.
+     * Note it is up to the collector to clear any existing events via [clearPendingEvent].
+     */
     val events: SharedFlow<Event?> = _events
 
+    /**
+     * Clears any existing [Event] from [events].
+     */
     fun clearPendingEvent() {
         _events.tryEmit(null)
     }
 
+    /**
+     * Try to authenticate via username/password. This will verify the credentials, and try to create
+     * an API key.
+     *
+     * @param serverName An optional name for the server. If this is blank, a name will be retrieved
+     * from the server.
+     * @param serverAddress The address of the server. For example, `http://truenas.local`.
+     * @param username The username to authenticate with.
+     * @param password The password to authenticate with.
+     */
     fun tryLogIn(
         serverName: String,
         serverAddress: String,
@@ -69,6 +94,14 @@ class AddServerViewModel(
         }
     }
 
+    /**
+     * Try to authenticate via API key.
+     *
+     * @param serverName An optional name for the server. If this is blank, a name will be retrieved
+     * from the server.
+     * @param serverAddress The address of the server. For example, `http://truenas.local`.
+     * @param apiKey The API key to try authenticate with.
+     */
     fun tryLogIn(
         serverName: String,
         serverAddress: String,
@@ -108,8 +141,8 @@ class AddServerViewModel(
         } catch (e: HttpsNotOkException) {
             apiStateProvider.authorization = null
             when (e.code) {
-                422 -> _events.emit(Event.LoginFailedKeyAlreadyExists)
-                401 -> _events.emit(Event.LoginFailedKeyInvalid)
+                HttpCodeUnprocessableEntity -> _events.emit(Event.LoginFailedKeyAlreadyExists)
+                HttpCodeUnauthorized -> _events.emit(Event.LoginFailedKeyInvalid)
                 else -> Log.e(::AddServerViewModel.name, "Unhandled exception $e")
             }
         } catch (_: IOException) {
@@ -118,6 +151,9 @@ class AddServerViewModel(
         }
     }
 
+    /**
+     * Describes various events that the ViewModel may emit.
+     */
     enum class Event {
         LoginSuccess,
         LoginFailedKeyInvalid,
@@ -125,5 +161,10 @@ class AddServerViewModel(
         LoginFailedUsernameOrPasswordInvalid,
         LoginFailedServerNotFound,
         LoginFailedNotHttps
+    }
+
+    companion object {
+        private const val HttpCodeUnprocessableEntity = 422
+        private const val HttpCodeUnauthorized = 401
     }
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AddServerViewModel.kt
@@ -2,6 +2,7 @@ package com.boswelja.truemanager.auth.ui.addserver
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.boswelja.truemanager.auth.serverstore.AuthenticatedServer
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStore
 import com.boswelja.truemanager.core.api.v2.ApiStateProvider
 import com.boswelja.truemanager.core.api.v2.Authorization
@@ -22,7 +23,12 @@ class AddServerViewModel(
     private val _isLoading = MutableStateFlow(false)
     val isLoading: StateFlow<Boolean> = _isLoading
 
-    fun tryLogIn(serverAddress: String, username: String, password: String) {
+    fun tryLogIn(
+        serverName: String,
+        serverAddress: String,
+        username: String,
+        password: String
+    ) {
         _isLoading.value = true
         apiStateProvider.serverAddress = serverAddress
         viewModelScope.launch {
@@ -30,15 +36,25 @@ class AddServerViewModel(
             if (isValid) {
                 apiStateProvider.authorization = Authorization.Basic(username, password)
                 val apiKey = apiKeyV2Api.create("TrueManager for TrueNAS")
-                // TODO
-                // authedServersStore.add(serverAddress, apiKey)
+                authedServersStore.add(
+                    AuthenticatedServer(
+                        uid = "TODO",
+                        serverAddress = serverAddress,
+                        token = apiKey,
+                        name = serverName
+                    )
+                )
                 apiStateProvider.authorization = Authorization.ApiKey(apiKey)
             }
             _isLoading.value = false
         }
     }
 
-    fun tryLogIn(serverAddress: String, apiKey: String) {
+    fun tryLogIn(
+        serverName: String,
+        serverAddress: String,
+        apiKey: String
+    ) {
         _isLoading.value = true
         apiStateProvider.serverAddress = serverAddress
         viewModelScope.launch {
@@ -46,6 +62,14 @@ class AddServerViewModel(
             delay(500)
             apiStateProvider.authorization = Authorization.ApiKey(apiKey)
             // TODO validate API key
+            authedServersStore.add(
+                AuthenticatedServer(
+                    uid = "TODO",
+                    serverAddress = serverAddress,
+                    token = apiKey,
+                    name = serverName
+                )
+            )
             _isLoading.value = false
         }
     }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AuthTypes.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/addserver/AuthTypes.kt
@@ -1,4 +1,4 @@
-package com.boswelja.truemanager.auth.ui
+package com.boswelja.truemanager.auth.ui.addserver
 
 import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/common/AuthHeader.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/common/AuthHeader.kt
@@ -1,0 +1,67 @@
+package com.boswelja.truemanager.auth.ui.common
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import com.boswelja.truemanager.auth.R
+import com.google.accompanist.drawablepainter.rememberDrawablePainter
+
+
+@Composable
+fun AuthHeader(
+    modifier: Modifier = Modifier
+) {
+    Surface(color = MaterialTheme.colorScheme.primaryContainer) {
+        Box(
+            modifier = modifier,
+            contentAlignment = Alignment.Center
+        ) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Image(painter = rememberAppIconPainter(), contentDescription = null)
+                Spacer(Modifier.width(16.dp))
+                Column {
+                    Text(
+                        text = buildAnnotatedString {
+                            append(stringResource(R.string.auth_header_true))
+                            withStyle(SpanStyle(fontWeight = FontWeight.SemiBold)) {
+                                append(stringResource(R.string.auth_header_manager))
+                            }
+                        },
+                        style = MaterialTheme.typography.headlineLarge
+                    )
+                    Text(
+                        text = stringResource(R.string.auth_header_label),
+                        style = MaterialTheme.typography.labelLarge,
+                        modifier = Modifier.padding(start = 4.dp)
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberAppIconPainter(): Painter {
+    val context = LocalContext.current
+    val icon = remember(context) { context.packageManager.getApplicationIcon(context.packageName) }
+    return rememberDrawablePainter(drawable = icon)
+}

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
@@ -1,5 +1,6 @@
 package com.boswelja.truemanager.auth.ui.serverselect
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,15 +17,18 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Dns
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.dp
 import com.boswelja.truemanager.auth.ui.common.AuthHeader
+import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
 
 @Composable
@@ -39,6 +43,18 @@ fun SelectServerScreen(
     val authenticatedServers by viewModel.authenticatedServers.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
 
+    LaunchedEffect(viewModel) {
+        viewModel.events.collectLatest {
+            when (it) {
+                SelectServerViewModel.Event.LoginSuccess -> onLoginSuccess()
+                SelectServerViewModel.Event.LoginFailedTokenInvalid -> TODO()
+                SelectServerViewModel.Event.LoginFailedServerNotFound -> TODO()
+                null -> return@collectLatest
+            }
+            viewModel.clearPendingEvent()
+        }
+    }
+
     Column(modifier) {
         AuthHeader(
             modifier = Modifier
@@ -46,6 +62,14 @@ fun SelectServerScreen(
                 .aspectRatio(16 / 9f)
                 .padding(contentPadding)
         )
+        AnimatedVisibility(visible = isLoading) {
+            LinearProgressIndicator(
+                modifier = Modifier.padding(
+                    start = contentPadding.calculateStartPadding(layoutDirection),
+                    end = contentPadding.calculateEndPadding(layoutDirection)
+                )
+            )
+        }
         Spacer(Modifier.height(16.dp))
         LazyColumn(
             contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding())

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.ui.Modifier
 import com.boswelja.truemanager.auth.ui.common.AuthHeader
 import org.koin.androidx.compose.koinViewModel
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SelectServerScreen(
     onLoginSuccess: () -> Unit,
@@ -44,11 +43,11 @@ fun SelectServerScreen(
             items = authenticatedServers,
             key = { it.token }
         ) { authenticatedServer ->
-            ListItem(headlineText = { Text(authenticatedServer.serverAddress) })
+            ListItem(headlineContent = { Text(authenticatedServer.serverAddress) })
         }
         item {
             ListItem(
-                headlineText = { Text("Add Server") },
+                headlineContent = { Text("Add Server") },
                 modifier = Modifier.clickable(onClick = onAddServer)
             )
         }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
@@ -1,0 +1,56 @@
+package com.boswelja.truemanager.auth.ui.serverselect
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ListItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import com.boswelja.truemanager.auth.ui.common.AuthHeader
+import org.koin.androidx.compose.koinViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SelectServerScreen(
+    onLoginSuccess: () -> Unit,
+    onAddServer: () -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(),
+    viewModel: SelectServerViewModel = koinViewModel()
+) {
+    val authenticatedServers by viewModel.authenticatedServers.collectAsState()
+
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding())
+    ) {
+        item {
+            AuthHeader(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16 / 9f)
+                    .padding(contentPadding)
+            )
+        }
+        items(
+            items = authenticatedServers,
+            key = { it.token }
+        ) { authenticatedServer ->
+            ListItem(headlineText = { Text(authenticatedServer.serverAddress) })
+        }
+        item {
+            ListItem(
+                headlineText = { Text("Add Server") },
+                modifier = Modifier.clickable(onClick = onAddServer)
+            )
+        }
+    }
+}

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerScreen.kt
@@ -1,19 +1,29 @@
 package com.boswelja.truemanager.auth.ui.serverselect
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.Dns
+import androidx.compose.material3.Icon
 import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.dp
 import com.boswelja.truemanager.auth.ui.common.AuthHeader
 import org.koin.androidx.compose.koinViewModel
 
@@ -25,31 +35,49 @@ fun SelectServerScreen(
     contentPadding: PaddingValues = PaddingValues(),
     viewModel: SelectServerViewModel = koinViewModel()
 ) {
+    val layoutDirection = LocalLayoutDirection.current
     val authenticatedServers by viewModel.authenticatedServers.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
 
-    LazyColumn(
-        modifier = modifier,
-        contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding())
-    ) {
-        item {
-            AuthHeader(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .aspectRatio(16 / 9f)
-                    .padding(contentPadding)
-            )
-        }
-        items(
-            items = authenticatedServers,
-            key = { it.token }
-        ) { authenticatedServer ->
-            ListItem(headlineContent = { Text(authenticatedServer.serverAddress) })
-        }
-        item {
-            ListItem(
-                headlineContent = { Text("Add Server") },
-                modifier = Modifier.clickable(onClick = onAddServer)
-            )
+    Column(modifier) {
+        AuthHeader(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16 / 9f)
+                .padding(contentPadding)
+        )
+        Spacer(Modifier.height(16.dp))
+        LazyColumn(
+            contentPadding = PaddingValues(bottom = contentPadding.calculateBottomPadding())
+        ) {
+            items(
+                items = authenticatedServers,
+                key = { it.token }
+            ) { authenticatedServer ->
+                ListItem(
+                    headlineContent = { Text(authenticatedServer.name) },
+                    supportingContent = { Text(authenticatedServer.serverAddress) },
+                    leadingContent = { Icon(Icons.Default.Dns, contentDescription = null) },
+                    modifier = Modifier
+                        .clickable(enabled = !isLoading) { viewModel.tryLogIn(authenticatedServer) }
+                        .padding(
+                            start = contentPadding.calculateStartPadding(layoutDirection),
+                            end = contentPadding.calculateEndPadding(layoutDirection)
+                        )
+                )
+            }
+            item {
+                ListItem(
+                    headlineContent = { Text("Add Server") },
+                    leadingContent = { Icon(Icons.Default.Add, contentDescription = null) },
+                    modifier = Modifier
+                        .clickable(onClick = onAddServer, enabled = !isLoading)
+                        .padding(
+                            start = contentPadding.calculateStartPadding(layoutDirection),
+                            end = contentPadding.calculateEndPadding(layoutDirection)
+                        )
+                )
+            }
         }
     }
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
@@ -6,7 +6,6 @@ import com.boswelja.truemanager.auth.serverstore.AuthenticatedServer
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStore
 import com.boswelja.truemanager.core.api.v2.ApiStateProvider
 import com.boswelja.truemanager.core.api.v2.Authorization
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -14,8 +13,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 class SelectServerViewModel(
+    private val apiStateProvider: ApiStateProvider,
     authenticatedServersStore: AuthenticatedServersStore,
-    private val apiStateProvider: ApiStateProvider
 ) : ViewModel() {
     val authenticatedServers = authenticatedServersStore.getAll()
         .stateIn(
@@ -34,7 +33,6 @@ class SelectServerViewModel(
             apiStateProvider.serverAddress = server.serverAddress
             apiStateProvider.authorization = Authorization.ApiKey(server.token)
             // TODO validate token
-            delay(500)
             _isLoading.value = false
         }
     }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
@@ -15,10 +15,16 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
+/**
+ * Responsible for exposing data to and handling events from the "select server" UI.
+ */
 class SelectServerViewModel(
     private val apiStateProvider: ApiStateProvider,
     authenticatedServersStore: AuthenticatedServersStore,
 ) : ViewModel() {
+    /**
+     * Flows a list of servers the user has previously authenticated with.
+     */
     val authenticatedServers = authenticatedServersStore.getAll()
         .stateIn(
             viewModelScope,
@@ -27,18 +33,34 @@ class SelectServerViewModel(
         )
 
     private val _isLoading = MutableStateFlow(false)
+
+    /**
+     * Whether the ViewModel is currently loading data. This should be used to switch the UI to a
+     * loading state.
+     */
     val isLoading: StateFlow<Boolean> = _isLoading
 
     private val _events = MutableSharedFlow<Event?>(
         replay = 1,
         onBufferOverflow = BufferOverflow.DROP_OLDEST
     )
+
+    /**
+     * Flows [Event]s coming from the ViewModel. If the value is null, there is no event to handle.
+     * Note it is up to the collector to clear any existing events via [clearPendingEvent].
+     */
     val events: SharedFlow<Event?> = _events
 
+    /**
+     * Clears any existing [Event] from [events].
+     */
     fun clearPendingEvent() {
         _events.tryEmit(null)
     }
 
+    /**
+     * Try log in to the given server.
+     */
     fun tryLogIn(server: AuthenticatedServer) {
         _isLoading.value = true
         viewModelScope.launch {
@@ -50,6 +72,9 @@ class SelectServerViewModel(
         }
     }
 
+    /**
+     * Describes various events that the ViewModel may emit.
+     */
     enum class Event {
         LoginSuccess,
         LoginFailedTokenInvalid,

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
@@ -2,12 +2,20 @@ package com.boswelja.truemanager.auth.ui.serverselect
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.boswelja.truemanager.auth.serverstore.AuthenticatedServer
 import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStore
+import com.boswelja.truemanager.core.api.v2.ApiStateProvider
+import com.boswelja.truemanager.core.api.v2.Authorization
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 
 class SelectServerViewModel(
-    authenticatedServersStore: AuthenticatedServersStore
+    authenticatedServersStore: AuthenticatedServersStore,
+    private val apiStateProvider: ApiStateProvider
 ) : ViewModel() {
     val authenticatedServers = authenticatedServersStore.getAll()
         .stateIn(
@@ -15,4 +23,19 @@ class SelectServerViewModel(
             SharingStarted.Eagerly,
             emptyList()
         )
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean>
+        get() = _isLoading
+
+    fun tryLogIn(server: AuthenticatedServer) {
+        _isLoading.value = true
+        viewModelScope.launch {
+            apiStateProvider.serverAddress = server.serverAddress
+            apiStateProvider.authorization = Authorization.ApiKey(server.token)
+            // TODO validate token
+            delay(500)
+            _isLoading.value = false
+        }
+    }
 }

--- a/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
+++ b/features/auth/src/main/kotlin/com/boswelja/truemanager/auth/ui/serverselect/SelectServerViewModel.kt
@@ -1,0 +1,18 @@
+package com.boswelja.truemanager.auth.ui.serverselect
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.boswelja.truemanager.auth.serverstore.AuthenticatedServersStore
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+
+class SelectServerViewModel(
+    authenticatedServersStore: AuthenticatedServersStore
+) : ViewModel() {
+    val authenticatedServers = authenticatedServersStore.getAll()
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            emptyList()
+        )
+}

--- a/features/auth/src/main/res/values/strings.xml
+++ b/features/auth/src/main/res/values/strings.xml
@@ -7,6 +7,10 @@
     <string name="auth_type_basic">Basic</string>
     <string name="auth_type_key">API Key</string>
 
+    <string name="invalid_basic_auth">The username and/or password you entered are invalid</string>
+    <string name="invalid_key_auth">The API key you entered is invalid</string>
+    <string name="invalid_server_address">Unable to reach the server</string>
+
     <string name="server_label">Server Address</string>
     <string name="username_label">Username</string>
     <string name="password_label">Password</string>

--- a/features/reporting/build.gradle.kts
+++ b/features/reporting/build.gradle.kts
@@ -55,8 +55,7 @@ dependencies {
 
     implementation(libs.vico)
 
-    implementation(libs.accompanist.navigation)
-    implementation(platform(libs.compose.bom))
+    implementation(libs.androidx.navigation)
     implementation(libs.bundles.compose)
     debugImplementation(libs.bundles.compose.tooling)
 

--- a/features/reporting/src/main/kotlin/com/boswelja/truemanager/reporting/Navigation.kt
+++ b/features/reporting/src/main/kotlin/com/boswelja/truemanager/reporting/Navigation.kt
@@ -1,15 +1,13 @@
 package com.boswelja.truemanager.reporting
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavGraphBuilder
-import com.google.accompanist.navigation.animation.composable
-import com.google.accompanist.navigation.animation.navigation
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
 
-@OptIn(ExperimentalAnimationApi::class)
 fun NavGraphBuilder.reportingGraph(route: String) {
     navigation(startDestination = "overview", route = route) {
         composable("overview") {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -45,6 +45,8 @@ androidx-window-testing = { group = "androidx.window", name = "window-testing", 
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 
+compose-animation = { group = "androidx.compose.animation", name = "animation", version.ref = "compose-animation" }
+compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "compose-foundation" }
 compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose-ui" }
 compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics", version.ref = "compose-ui" }
 compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose-ui" }
@@ -88,6 +90,8 @@ kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 compose = [
     "activity-compose",
     "viewmodel-compose",
+    "compose-animation",
+    "compose-foundation",
     "compose-ui",
     "compose-ui-graphics",
     "compose-ui-tooling-preview",

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ androidx-window = "1.1.0-beta02"
 
 activity-compose = "1.7.0"
 compose-bom = "2023.04.00"
-accompanist = "0.30.1"
+accompanist = "0.31.0-alpha"
 
 room = "2.5.1"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,10 +6,17 @@ ksp = "1.8.20-1.0.11"
 
 androidx-core = "1.10.0"
 androidx-lifecycle = "2.6.1"
+androidx-navigation = "2.6.0-beta01"
 androidx-window = "1.1.0-beta02"
 
-activity-compose = "1.7.0"
-compose-bom = "2023.04.00"
+activity-compose = "1.7.1"
+compose-animation = "1.5.0-alpha03"
+compose-compiler = "1.4.6"
+compose-foundation = "1.5.0-alpha03"
+compose-icons = "1.5.0-alpha03"
+compose-material3 = "1.1.0-rc01"
+compose-runtime = "1.5.0-alpha03"
+compose-ui = "1.5.0-alpha03"
 accompanist = "0.31.0-alpha"
 
 room = "2.5.1"
@@ -31,23 +38,22 @@ espresso-core = "3.5.1"
 [libraries]
 androidx-core = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core" }
 androidx-lifecycle-runtime = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+androidx-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidx-navigation" }
 androidx-window = { group = "androidx.window", name = "window", version.ref = "androidx-window" }
 androidx-window-testing = { group = "androidx.window", name = "window-testing", version.ref = "androidx-window" }
 
 activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activity-compose" }
 viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 
-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "compose-bom" }
-compose-ui = { group = "androidx.compose.ui", name = "ui" }
-compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics" }
-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-compose-icons = { group = "androidx.compose.material", name = "material-icons-extended"}
-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
+compose-ui = { group = "androidx.compose.ui", name = "ui", version.ref = "compose-ui" }
+compose-ui-graphics = { group = "androidx.compose.ui", name = "ui-graphics", version.ref = "compose-ui" }
+compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling", version.ref = "compose-ui" }
+compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview", version.ref = "compose-ui" }
+compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest", version.ref = "compose-ui" }
+compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4", version.ref = "compose-ui" }
+compose-icons = { group = "androidx.compose.material", name = "material-icons-extended", version.ref = "compose-icons" }
+compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "compose-material3" }
 accompanist-drawablepainter = { group = "com.google.accompanist", name = "accompanist-drawablepainter", version.ref = "accompanist" }
-accompanist-navigation = { group = "com.google.accompanist", name = "accompanist-navigation-animation", version.ref = "accompanist" }
 
 room-runtime = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
We now properly store generated API keys, and can log in to servers that were previously authenticated with one touch. This still needs work to be more user-friendly and handle more edge cases, but in its current state it will speed up development by a lot