### PR TITLE
Specify a type enum for dashboard configuration items rather than an ID

### DIFF
--- a/features/dashboard/schemas/com.boswelja.truemanager.dashboard.configuration.database.DashboardEntryDatabase/1.json
+++ b/features/dashboard/schemas/com.boswelja.truemanager.dashboard.configuration.database.DashboardEntryDatabase/1.json
@@ -2,15 +2,15 @@
   "formatVersion": 1,
   "database": {
     "version": 1,
-    "identityHash": "c0091bae3335793048797b2fb63cb177",
+    "identityHash": "f79007615c21ce49e6fc4828628bed61",
     "entities": [
       {
         "tableName": "dashboard_entry",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `server_id` TEXT NOT NULL, `is_visible` INTEGER NOT NULL, `priority` INTEGER NOT NULL, PRIMARY KEY(`id`, `server_id`))",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`type` TEXT NOT NULL, `server_id` TEXT NOT NULL, `is_visible` INTEGER NOT NULL, `priority` INTEGER NOT NULL, PRIMARY KEY(`type`, `server_id`))",
         "fields": [
           {
-            "fieldPath": "id",
-            "columnName": "id",
+            "fieldPath": "type",
+            "columnName": "type",
             "affinity": "TEXT",
             "notNull": true
           },
@@ -36,7 +36,7 @@
         "primaryKey": {
           "autoGenerate": false,
           "columnNames": [
-            "id",
+            "type",
             "server_id"
           ]
         },
@@ -47,7 +47,7 @@
     "views": [],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c0091bae3335793048797b2fb63cb177')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f79007615c21ce49e6fc4828628bed61')"
     ]
   }
 }

--- a/features/dashboard/src/main/kotlin/com/boswelja/truemanager/dashboard/configuration/DashboardConfiguration.kt
+++ b/features/dashboard/src/main/kotlin/com/boswelja/truemanager/dashboard/configuration/DashboardConfiguration.kt
@@ -13,9 +13,14 @@ interface DashboardConfiguration {
     fun getVisibleEntries(serverId: String): Flow<List<DashboardEntry>>
 
     /**
+     * Get whether the server with the given ID has any entries associated at all.
+     */
+    suspend fun hasAnyEntries(serverId: String): Boolean
+
+    /**
      * Moves the entry with the given ID for the specified server up or down in the priority list.
      */
-    suspend fun reorderEntry(serverId: String, entryId: String, newPriority: Int)
+    suspend fun reorderEntry(serverId: String, entryType: DashboardEntry.Type, newPriority: Int)
 
     /**
      * Adds new [DashboardEntry]s to the store.
@@ -25,20 +30,27 @@ interface DashboardConfiguration {
     /**
      * Sets whether the specified entry is visible.
      */
-    suspend fun setEntryVisible(serverId: String, entryId: String, isVisible: Boolean)
+    suspend fun setEntryVisible(serverId: String, entryType: DashboardEntry.Type, isVisible: Boolean)
 }
 
 /**
  * Describes an entry on the dashboard.
  *
- * @property id The ID of the entry, unique to this server.
+ * @property type The ID of dashboard card.
  * @property serverId The unique ID of the server this entry belongs to.
  * @property isVisible Whether this entry is visible on the dashboard.
  * @property priority THe priority of this entry. A lower number is displayed higher in the list.
  */
 data class DashboardEntry(
-    val id: String,
+    val type: Type,
     val serverId: String,
     val isVisible: Boolean,
     val priority: Int
-)
+) {
+    enum class Type {
+        SYSTEM_INFORMATION,
+        CPU,
+        MEMORY,
+        NETWORK,
+    }
+}

--- a/features/dashboard/src/main/kotlin/com/boswelja/truemanager/dashboard/configuration/database/DashboardEntryDao.kt
+++ b/features/dashboard/src/main/kotlin/com/boswelja/truemanager/dashboard/configuration/database/DashboardEntryDao.kt
@@ -19,14 +19,14 @@ internal interface DashboardEntryDao {
     @Update
     suspend fun update(entries: List<DashboardEntryEntity>)
 
-    @Query("UPDATE dashboard_entry SET is_visible = :isVisible WHERE id = :entryId AND server_id = :serverId")
-    suspend fun update(serverId: String, entryId: String, isVisible: Boolean)
+    @Query("UPDATE dashboard_entry SET is_visible = :isVisible WHERE type = :entryType AND server_id = :serverId")
+    suspend fun update(serverId: String, entryType: String, isVisible: Boolean)
 
     @Query("SELECT * FROM dashboard_entry WHERE priority >= :maxPriority AND server_id = :serverId")
     suspend fun getLowerPriority(serverId: String, maxPriority: Int): List<DashboardEntryEntity>
 
-    @Query("SELECT * FROM dashboard_entry WHERE id = :entryId AND server_id = :serverId LIMIT 1")
-    suspend fun get(serverId: String, entryId: String): DashboardEntryEntity
+    @Query("SELECT * FROM dashboard_entry WHERE type = :entryType AND server_id = :serverId LIMIT 1")
+    suspend fun get(serverId: String, entryType: String): DashboardEntryEntity
 
     @Query("SELECT * FROM dashboard_entry WHERE is_visible = 1 AND server_id = :serverId ORDER BY priority")
     fun getVisible(serverId: String): Flow<List<DashboardEntryEntity>>

--- a/features/dashboard/src/main/kotlin/com/boswelja/truemanager/dashboard/configuration/database/DashboardEntryEntity.kt
+++ b/features/dashboard/src/main/kotlin/com/boswelja/truemanager/dashboard/configuration/database/DashboardEntryEntity.kt
@@ -5,11 +5,11 @@ import androidx.room.Entity
 
 @Entity(
     tableName = "dashboard_entry",
-    primaryKeys = ["id", "server_id"]
+    primaryKeys = ["type", "server_id"]
 )
 internal data class DashboardEntryEntity(
-    @ColumnInfo(name = "id")
-    val id: String,
+    @ColumnInfo(name = "type")
+    val type: String,
     @ColumnInfo(name = "server_id")
     val serverId: String,
     @ColumnInfo(name = "is_visible")


### PR DESCRIPTION
I didn't bump the Room DB version despite the schema change, there should be no data in the database.