### PR TITLE
Introduce a new unique primary key to the dashboard configuration system

### DIFF
--- a/features/dashboard/data/schemas/com.boswelja.truemanager.data.configuration.database.DashboardEntryDatabase/3.json
+++ b/features/dashboard/data/schemas/com.boswelja.truemanager.data.configuration.database.DashboardEntryDatabase/3.json
@@ -1,0 +1,58 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "cd32fea034aebb0cd1eb586de334e663",
+    "entities": [
+      {
+        "tableName": "dashboard_entry",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `server_id` TEXT NOT NULL, `is_visible` INTEGER NOT NULL, `priority` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "serverId",
+            "columnName": "server_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isVisible",
+            "columnName": "is_visible",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "priority",
+            "columnName": "priority",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'cd32fea034aebb0cd1eb586de334e663')"
+    ]
+  }
+}

--- a/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/DashboardConfiguration.kt
+++ b/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/DashboardConfiguration.kt
@@ -36,12 +36,14 @@ interface DashboardConfiguration {
 /**
  * Describes an entry on the dashboard.
  *
+ * @property uid A unique identifier for this item.
  * @property type The type of dashboard entry.
  * @property serverId The unique ID of the server this entry belongs to.
  * @property isVisible Whether this entry is visible on the dashboard.
  * @property priority THe priority of this entry. A lower number is displayed higher in the list.
  */
 data class DashboardEntry(
+    val uid: Long,
     val type: Type,
     val serverId: String,
     val isVisible: Boolean,

--- a/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/database/DashboardConfigurationDatabaseImpl.kt
+++ b/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/database/DashboardConfigurationDatabaseImpl.kt
@@ -20,7 +20,7 @@ class DashboardConfigurationDatabaseImpl(
         context,
         DashboardEntryDatabase::class.java,
         "dashboard-configuration"
-    ).build()
+    ).fallbackToDestructiveMigration().build()
 
     @OptIn(ExperimentalCoroutinesApi::class)
     override fun getVisibleEntries(serverId: String): Flow<List<DashboardEntry>> = database.getDashboardEntryDao()
@@ -28,6 +28,7 @@ class DashboardConfigurationDatabaseImpl(
         .mapLatest {
             it.map { entity ->
                 DashboardEntry(
+                    entity.uid,
                     DashboardEntry.Type.valueOf(entity.type),
                     entity.serverId,
                     entity.isVisible,
@@ -56,7 +57,7 @@ class DashboardConfigurationDatabaseImpl(
     override suspend fun insertEntries(entries: List<DashboardEntry>) {
         database.getDashboardEntryDao().add(
             entries.map {
-                DashboardEntryEntity(it.type.name, it.serverId, it.isVisible, it.priority)
+                DashboardEntryEntity(it.uid, it.type.name, it.serverId, it.isVisible, it.priority)
             }
         )
     }

--- a/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/database/DashboardEntryDatabase.kt
+++ b/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/database/DashboardEntryDatabase.kt
@@ -3,7 +3,7 @@ package com.boswelja.truemanager.data.configuration.database
 import androidx.room.Database
 import androidx.room.RoomDatabase
 
-@Database(entities = [DashboardEntryEntity::class], version = 2)
+@Database(entities = [DashboardEntryEntity::class], version = 3)
 internal abstract class DashboardEntryDatabase : RoomDatabase() {
 
     abstract fun getDashboardEntryDao(): DashboardEntryDao

--- a/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/database/DashboardEntryEntity.kt
+++ b/features/dashboard/data/src/main/kotlin/com/boswelja/truemanager/data/configuration/database/DashboardEntryEntity.kt
@@ -2,12 +2,13 @@ package com.boswelja.truemanager.data.configuration.database
 
 import androidx.room.ColumnInfo
 import androidx.room.Entity
+import androidx.room.PrimaryKey
 
-@Entity(
-    tableName = "dashboard_entry",
-    primaryKeys = ["priority", "server_id"]
-)
+@Entity(tableName = "dashboard_entry")
 internal data class DashboardEntryEntity(
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo("uid")
+    val uid: Long,
     @ColumnInfo(name = "type")
     val type: String,
     @ColumnInfo(name = "server_id")

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/configuration/InitializeDashboard.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/configuration/InitializeDashboard.kt
@@ -22,6 +22,7 @@ class InitializeDashboard(
             configuration.insertEntries(
                 DashboardEntry.Type.values().mapIndexed { index, type ->
                     DashboardEntry(
+                        uid = 0,
                         type = type,
                         serverId = serverId,
                         isVisible = true,

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractCpuUsageData.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractCpuUsageData.kt
@@ -23,7 +23,7 @@ class ExtractCpuUsageData {
         systemInformation: SystemInfo,
         usageGraph: ReportingGraphData,
         temperatureGraph: ReportingGraphData,
-        uid: String,
+        uid: Long,
     ): DashboardData.CpuData {
         // Usage data comes to us as a 2d array. We get the last set of values that aren't null,
         // i.e. the most recent recorded values, then take the "idle" percentage from that.

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractDashboardData.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractDashboardData.kt
@@ -28,7 +28,7 @@ class ExtractDashboardData(
         systemInfo: SystemInfo,
     ): List<DashboardData> {
         return entries.map { entry ->
-            val uid = entry.serverId + entry.type
+            val uid = entry.uid
             when (entry.type) {
                 DashboardEntry.Type.SYSTEM_INFORMATION -> {
                     extractSystemInformationData(uid = uid, systemInfo = systemInfo)

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractMemoryUsageData.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractMemoryUsageData.kt
@@ -21,7 +21,7 @@ class ExtractMemoryUsageData {
     operator fun invoke(
         systemInformation: SystemInfo,
         memoryGraph: ReportingGraphData,
-        uid: String,
+        uid: Long,
     ): DashboardData.MemoryData {
         val memoryData = memoryGraph.data.last { !it.contains(null) } as List<Double>
         return DashboardData.MemoryData(

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractNetworkUsageData.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractNetworkUsageData.kt
@@ -20,7 +20,7 @@ class ExtractNetworkUsageData {
      */
     operator fun invoke(
         adapterGraphs: List<ReportingGraphData>,
-        uid: String,
+        uid: Long,
     ): DashboardData.NetworkUsageData {
         val adaptersInfo = adapterGraphs
             .filter { graph -> graph.data.any { line -> line.any { point -> point != null && point > 0 } } }

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractSystemInformationData.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/ExtractSystemInformationData.kt
@@ -19,7 +19,7 @@ class ExtractSystemInformationData {
      */
     operator fun invoke(
         systemInfo: SystemInfo,
-        uid: String,
+        uid: Long,
     ): DashboardData.SystemInformationData {
         return DashboardData.SystemInformationData(
             uid = uid,

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/GetDashboardData.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/dataloading/GetDashboardData.kt
@@ -70,7 +70,7 @@ sealed interface DashboardData {
     /**
      * A unique identifier for this item.
      */
-    val uid: String
+    val uid: Long
 
     /**
      * Describes the CPU in the system.
@@ -84,7 +84,7 @@ sealed interface DashboardData {
      * core.
      */
     data class CpuData(
-        override val uid: String,
+        override val uid: Long,
         val name: String,
         val cores: Int,
         val threads: Int,
@@ -101,7 +101,7 @@ sealed interface DashboardData {
      * @property isEcc Whether the memory supports ECC.
      */
     data class MemoryData(
-        override val uid: String,
+        override val uid: Long,
         val memoryUsed: Capacity,
         val memoryFree: Capacity,
         val isEcc: Boolean
@@ -124,7 +124,7 @@ sealed interface DashboardData {
      * @property adaptersData A list of [AdapterData] describing a single adapter.
      */
     data class NetworkUsageData(
-        override val uid: String,
+        override val uid: Long,
         val adaptersData: List<AdapterData>
     ) : DashboardData {
 
@@ -157,7 +157,7 @@ sealed interface DashboardData {
      * @property lastBootTime The time the system was last started. This is used to calculate uptime.
      */
     data class SystemInformationData(
-        override val uid: String,
+        override val uid: Long,
         val version: String,
         val hostname: String,
         val lastBootTime: LocalDateTime

--- a/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/CpuOverview.kt
+++ b/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/CpuOverview.kt
@@ -127,7 +127,7 @@ fun CpuOverviewPreview() {
                 threads = 56,
                 tempCelsius = 31,
                 utilisation = 0.43f,
-                uid = "cpu"
+                uid = 0
             ),
             modifier = Modifier.fillMaxWidth().padding(16.dp)
         )

--- a/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/MemoryOverview.kt
+++ b/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/MemoryOverview.kt
@@ -128,7 +128,7 @@ fun MemoryCardPreview() {
                 memoryUsed = 51.1.gigabytes,
                 memoryFree = 128.gigabytes - 51.1.gigabytes,
                 isEcc = true,
-                uid = "memory"
+                uid = 0
             ),
             modifier = Modifier.fillMaxWidth().padding(16.dp)
         )

--- a/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/NetworkOverview.kt
+++ b/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/NetworkOverview.kt
@@ -140,7 +140,7 @@ fun NetworkOverviewPreview() {
         val incomingRand = Random(0)
         val outgoingRandom = Random(10)
         DashboardData.NetworkUsageData(
-            uid = "network",
+            uid = 0,
             adaptersData = listOf(
                 DashboardData.NetworkUsageData.AdapterData(
                     name = "eno1",

--- a/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/SystemInformationOverview.kt
+++ b/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/cards/SystemInformationOverview.kt
@@ -103,7 +103,7 @@ fun SystemInformationOverviewPreview() {
             version = "TrueNAS-SCALE-22.12.2",
             hostname = "truenas",
             lastBootTime = LocalDateTime(2023, 3, 1, 10, 33),
-            uid = "sysinfo"
+            uid = 0
         ),
         modifier = Modifier.fillMaxWidth().padding(16.dp)
     )


### PR DESCRIPTION
This should allow us to introduce multiple items of the same type for any given server, not that we need that right now