### PR TITLE
Allow saving dashboard order

### DIFF
--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/DI.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/DI.kt
@@ -2,6 +2,7 @@ package com.boswelja.truemanager.dashboard.logic
 
 import com.boswelja.truemanager.dashboard.logic.configuration.InitializeDashboard
 import com.boswelja.truemanager.dashboard.logic.configuration.ReorderDashboardData
+import com.boswelja.truemanager.dashboard.logic.configuration.SaveDashboardOrder
 import com.boswelja.truemanager.dashboard.logic.dataloading.ExtractCpuUsageData
 import com.boswelja.truemanager.dashboard.logic.dataloading.ExtractDashboardData
 import com.boswelja.truemanager.dashboard.logic.dataloading.ExtractMemoryUsageData
@@ -28,6 +29,8 @@ val dashboardBusinessModule = module {
     factoryOf(::ExtractSystemInformationData)
     factoryOf(::GetDashboardData)
     factoryOf(::GetReportingDataForEntries)
+
     factoryOf(::InitializeDashboard)
     factoryOf(::ReorderDashboardData)
+    factoryOf(::SaveDashboardOrder)
 }

--- a/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/configuration/SaveDashboardOrder.kt
+++ b/features/dashboard/logic/src/main/kotlin/com/boswelja/truemanager/dashboard/logic/configuration/SaveDashboardOrder.kt
@@ -1,0 +1,36 @@
+package com.boswelja.truemanager.dashboard.logic.configuration
+
+import com.boswelja.truemanager.core.api.v2.system.SystemV2Api
+import com.boswelja.truemanager.dashboard.logic.dataloading.DashboardData
+import com.boswelja.truemanager.data.configuration.DashboardConfiguration
+import com.boswelja.truemanager.data.configuration.DashboardEntry
+
+/**
+ * Save the order of the given list of dashboard data. See [invoke] for details.
+ */
+class SaveDashboardOrder(
+    private val configuration: DashboardConfiguration,
+    private val systemV2Api: SystemV2Api
+) {
+
+    /**
+     * Saves the order of the list of [DashboardData] to the database configuration store.
+     */
+    suspend operator fun invoke(data: List<DashboardData>) {
+        val entries = data.mapIndexed { index, dashboardData ->
+            DashboardEntry(
+                uid = dashboardData.uid,
+                type = when (dashboardData) {
+                    is DashboardData.CpuData -> DashboardEntry.Type.CPU
+                    is DashboardData.MemoryData -> DashboardEntry.Type.MEMORY
+                    is DashboardData.NetworkUsageData -> DashboardEntry.Type.NETWORK
+                    is DashboardData.SystemInformationData -> DashboardEntry.Type.SYSTEM_INFORMATION
+                },
+                serverId = systemV2Api.getHostId(),
+                isVisible = true,
+                priority = index
+            )
+        }
+        configuration.update(entries)
+    }
+}

--- a/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/OverviewViewModel.kt
+++ b/features/dashboard/ui/src/main/kotlin/com/boswelja/truemanager/dashboard/ui/overview/OverviewViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.boswelja.truemanager.dashboard.logic.configuration.InitializeDashboard
 import com.boswelja.truemanager.dashboard.logic.configuration.ReorderDashboardData
+import com.boswelja.truemanager.dashboard.logic.configuration.SaveDashboardOrder
 import com.boswelja.truemanager.dashboard.logic.dataloading.DashboardData
 import com.boswelja.truemanager.dashboard.logic.dataloading.GetDashboardData
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -20,6 +21,7 @@ class OverviewViewModel(
     private val initializeDashboard: InitializeDashboard,
     private val getDashboardData: GetDashboardData,
     private val reorderDashboardData: ReorderDashboardData,
+    private val saveDashboardOrder: SaveDashboardOrder,
 ) : ViewModel() {
 
     private val _editingList = MutableStateFlow<List<DashboardData>?>(null)
@@ -74,6 +76,11 @@ class OverviewViewModel(
     fun moveDashboardEntry(from: Int, to: Int) {
         _editingList.update { editingList ->
             editingList?.let { reorderDashboardData(it, from, to) }
+        }
+        viewModelScope.launch {
+            _editingList.value?.let {
+                saveDashboardOrder(it)
+            }
         }
     }
 }


### PR DESCRIPTION
This will save the dashboard order in the background as the user reorders it, which might lead to race conditions but seems to be working OK so far. We will cross that bridge when it comes to it